### PR TITLE
Introducing a `destroyOnExit` instance creation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ import craftai from 'craft-ai-client-js';
 ````js
 craftai({
   owner: '<project_owner>',
-  name: "<project_name>",
-  version: "<project_version>",
-  appId: "<app_id>",
-  appSecret: "<app_secret>"
+  name: '<project_name>',
+  version: '<project_version>',
+  appId: '<app_id>',
+  appSecret: '<app_secret>',
+  destroyOnExit: true/false
 })
 .then(function(instance) {
   // Use your instance here
@@ -49,6 +50,19 @@ craftai({
   // Catch errors here
 })
 ````
+
+### `destroyOnExit` ###
+
+If `true`, the instance will destroy itself when the window unloads or the
+process exits.
+
+- The **browser** version relies on the
+[_beforeunload_](https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload)
+event.
+- The **nodejs** version relies on the
+[_uncaughtException_](https://nodejs.org/api/process.html#process_event_uncaughtexception),
+[_unhandledrejection_](https://nodejs.org/api/process.html#process_event_unhandledrejection),
+[_SIGINT_, _SIGTERM_, _SIGQUIT_ and _SIGHUP_](https://nodejs.org/api/process.html#process_signal_events) events.
 
 ## 2. Register actions ##
 

--- a/lib/createInstance.js
+++ b/lib/createInstance.js
@@ -3,7 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.IN_BROWSER = undefined;
 exports.default = createInstance;
 
 var _lodash = require('lodash');
@@ -18,6 +17,10 @@ var _isomorphicFetch = require('isomorphic-fetch');
 
 var _isomorphicFetch2 = _interopRequireDefault(_isomorphicFetch);
 
+var _onExit = require('./onExit');
+
+var _onExit2 = _interopRequireDefault(_onExit);
+
 var _status = require('./status');
 
 var _status2 = _interopRequireDefault(_status);
@@ -28,7 +31,7 @@ var _ws2 = _interopRequireDefault(_ws);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var IN_BROWSER = exports.IN_BROWSER = typeof window !== 'undefined';
+var IN_BROWSER = typeof window !== 'undefined';
 
 var START_SUFFIX = '#s';
 var CANCEL_SUFFIX = '#c'; // START_SUFFIX.length === CANCEL_SUFFIX.length
@@ -133,12 +136,19 @@ function createInstance(cfg) {
     };
   };
 
+  // Function that'll be called when the instance is destroyed.
+  var cleanupDestroyOnExit = function cleanupDestroyOnExit() {
+    return undefined;
+  };
+
   return request({
     method: 'PUT'
   }).then(function (json) {
+
     status = _status2.default.running;
     instanceId = json.instance.instance_id;
-    return {
+
+    var instance = {
       id: instanceId,
       getStatus: function getStatus() {
         return status;
@@ -148,29 +158,16 @@ function createInstance(cfg) {
       },
       destroy: function destroy() {
         status = _status2.default.stopping;
-        if (IN_BROWSER === true) {
-          return new Promise(function (resolve, reject) {
-            // Using directly a XMLHttpRequest to handle properly the destruction on the window destruction
-            var oReq = new XMLHttpRequest();
-            oReq.open('DELETE', httpUrl + '/' + instanceId, false);
-            oReq.setRequestHeader('content-type', 'application/json; charset=utf-8');
-            oReq.setRequestHeader('accept', '');
-            oReq.setRequestHeader('X-Craft-Ai-App-Id', appId);
-            oReq.setRequestHeader('X-Craft-Ai-App-Secret', appSecret);
-            oReq.send();
-            status = _status2.default.destroyed; // This should be done when craft respond
-          });
-        } else {
-            return request({
-              method: 'DELETE',
-              path: '/' + instanceId
-            }).then(function (res) {
-              status = _status2.default.destroyed;
-            }).catch(function (err) {
-              status = _status2.default.destroyed;
-              return Promise.reject(err);
-            });
-          }
+        return request({
+          method: 'DELETE',
+          path: '/' + instanceId
+        }).then(function () {
+          cleanupDestroyOnExit();
+          status = _status2.default.destroyed;
+        }).catch(function (err) {
+          status = _status2.default.destroyed;
+          return Promise.reject(err);
+        });
       },
       registerAction: function registerAction(name, start) {
         var cancel = arguments.length <= 2 || arguments[2] === undefined ? function () {
@@ -273,5 +270,25 @@ function createInstance(cfg) {
         }
       }
     };
+
+    if (cfg.destroyOnExit) {
+      cleanupDestroyOnExit = (0, _onExit2.default)(function () {
+        if (IN_BROWSER) {
+          // Using directly a XMLHttpRequest to make a synchronous call.
+          var oReq = new XMLHttpRequest();
+          oReq.open('DELETE', httpUrl + '/' + instance.id, false);
+          oReq.setRequestHeader('content-type', 'application/json; charset=utf-8');
+          oReq.setRequestHeader('accept', '');
+          oReq.setRequestHeader('X-Craft-Ai-App-Id', appId);
+          oReq.setRequestHeader('X-Craft-Ai-App-Secret', appSecret);
+          instance.status = _status2.default.destroyed;
+          oReq.send();
+        } else {
+          instance.destroy();
+        }
+      });
+    }
+
+    return instance;
   });
 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 var DEFAULTS = {
   appId: process.env.CRAFT_APP_ID,
   appSecret: process.env.CRAFT_APP_SECRET,
+  destroyOnExit: true,
   httpApiUrl: process.env.CRAFT_HTTP_API_URL || 'https://api.craft.ai/v1',
   wsApiUrl: process.env.CRAFT_WS_API_URL || 'wss://api.craft.ai/v1',
   hubApiUrl: process.env.CRAFT_HUB_API_URL || 'https://hub.craft.ai/v1'

--- a/lib/onExit.js
+++ b/lib/onExit.js
@@ -1,0 +1,43 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var IN_BROWSER = typeof window !== 'undefined';
+
+function onWindowCloses(cb) {
+  var listener = function listener() {
+    cb();
+  };
+  window.addEventListener('beforeunload', listener);
+  return function () {
+    return window.removeEventListener(listener);
+  };
+}
+
+var NODE_PROCESS_EVENT = ['unhandledRejection', 'uncaughtException', 'SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP'];
+
+function onProcessQuits(cb) {
+  var listener = function listener() {
+    cb();
+  };
+  _lodash2.default.map(NODE_PROCESS_EVENT, function (evt) {
+    return process.on(evt, listener);
+  });
+  return function () {
+    return _lodash2.default.map(NODE_PROCESS_EVENT, function (evt) {
+      return process.removeListener(evt, listener);
+    });
+  };
+}
+
+var onExit = IN_BROWSER ? onWindowCloses : onProcessQuits;
+
+exports.default = onExit;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,6 +1,7 @@
 const DEFAULTS = {
   appId: process.env.CRAFT_APP_ID,
   appSecret: process.env.CRAFT_APP_SECRET,
+  destroyOnExit: true,
   httpApiUrl: process.env.CRAFT_HTTP_API_URL || 'https://api.craft.ai/v1',
   wsApiUrl: process.env.CRAFT_WS_API_URL || 'wss://api.craft.ai/v1',
   hubApiUrl: process.env.CRAFT_HUB_API_URL || 'https://hub.craft.ai/v1'

--- a/src/onExit.js
+++ b/src/onExit.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+
+const IN_BROWSER = typeof window !== 'undefined';
+
+function onWindowCloses(cb) {
+  const listener = () => {
+    cb();
+  };
+  window.addEventListener('beforeunload', listener);
+  return () => window.removeEventListener(listener);
+}
+
+const NODE_PROCESS_EVENT = [
+  'unhandledRejection',
+  'uncaughtException',
+  'SIGINT',
+  'SIGTERM',
+  'SIGQUIT',
+  'SIGHUP'
+];
+
+function onProcessQuits(cb) {
+  const listener = () => {
+    cb();
+  };
+  _.map(NODE_PROCESS_EVENT, evt => process.on(evt, listener));
+  return () => _.map(NODE_PROCESS_EVENT, evt => process.removeListener(evt, listener));
+}
+
+let onExit = IN_BROWSER ? onWindowCloses : onProcessQuits;
+
+export default onExit;


### PR DESCRIPTION
It destroy the instance when the window unloads (in browsers) or the process ends (in nodes) and thus facilitates a quick start.

- [x] Validated
- [x] craft-ai/craft-ai-starterkit-nodejs#2 validated
- [x] craft-ai/ni#1 validated