### PR TITLE
creating an instance now returns an object 'instance' with the attribute 'id'

### DIFF
--- a/src/createInstance.js
+++ b/src/createInstance.js
@@ -120,7 +120,7 @@ export default function createInstance(cfg) {
     status = STATUS.running;
     instanceId = json.instance.instance_id;
     return {
-      instanceId: instanceId,
+      id: instanceId,
       getStatus: function() {
         return status;
       },

--- a/test/test_instanceCreation.js
+++ b/test/test_instanceCreation.js
@@ -20,7 +20,7 @@ describe('craftai', function() {
       this.timeout(5000);
       return craftai(CRAFT_CFG)
         .then(instance => {
-          assert.notEqual(instance.instanceId , undefined);
+          assert.notEqual(instance.id , undefined);
           assert.equal(instance.getStatus() , STATUS.running);
           return instance.destroy()
             .then(() => {


### PR DESCRIPTION
 (instead of 'instanceId')