### PR TITLE
Feature/init instance knowledge

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,7 +35,8 @@ craftai({
   appId: '<app_id>',
   appSecret: '<app_secret>',
   destroyOnExit: true/false
-})
+},
+<init_knowledge>)
 .then(function(instance) {
   // Use your instance here
   // instance = {

--- a/src/createInstance.js
+++ b/src/createInstance.js
@@ -13,7 +13,7 @@ const CANCEL_SUFFIX = '#c'; // START_SUFFIX.length === CANCEL_SUFFIX.length
 
 let debug = Debug('craft-ai:client');
 
-export default function createInstance(cfg) {
+export default function createInstance(cfg, knowledge) {
   cfg = _.defaults(cfg, DEFAULTS);
   if (!_.has(cfg, 'owner') || !_.isString(cfg.owner)) {
     return Promise.reject(new errors.CraftAiBadRequestError('Bad Request, unable to create an instance with no or invalid project owner provided.'));
@@ -87,7 +87,10 @@ export default function createInstance(cfg) {
   let cleanupDestroyOnExit = () => undefined;
 
   return request({
-    method: 'PUT'
+    method: 'PUT',
+    body: {
+      knowledge: knowledge
+    }
   }, cfg)
   .then(json => {
 

--- a/test/test_createInstance.js
+++ b/test/test_createInstance.js
@@ -18,6 +18,27 @@ describe('craftai(<config>)', function() {
           });
       })
   });
+  it('should create an instance with an initial knowledge', function() {
+    const INITIAL_KNOWLEDGE = {
+      foo: 'fluctuat nec mergitur',
+      bar: [true, 34.3, 'alea jacta est'],
+      baz: 42
+    };
+    this.timeout(5000);
+    return craftai(CRAFT_CFG, INITIAL_KNOWLEDGE)
+      .then(instance => {
+        expect(instance.id).to.be.ok;
+        expect(instance.getStatus()).to.be.equal(STATUS.running);
+        return instance.getInstanceKnowledge()
+          .then(k => {
+            expect(k).to.be.deep.equal(INITIAL_KNOWLEDGE);
+            return instance.destroy()
+              .then(() => {
+                expect(instance.getStatus()).to.be.equal(STATUS.destroyed);
+              });
+          });
+      })
+  });
   it('should fail when using invalid APP_ID/APP_SECRET', function() {
     return craftai(_.extend(_.clone(CRAFT_CFG), {
         appId: 'baaaah',


### PR DESCRIPTION
Matches [API v0.18](http://doc.craft.ai/changelog.html#2016-01-13)
- Adding the possibility to provide an initial knowledge when creating an instance.