### PR TITLE
Facilitate the installation of any branch via npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,1 @@
-test
-src
 .travis.yml
-.eslintrc

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -13,9 +13,10 @@ CRAFT_APP_SECRET=<retrieved_appSecret>
 ````
 4. Run `npm install` to install dependencies
 5. You can run the following `npm` scripts:
-  - `npm run test_node` launches the tests in a nodejs context
+  - `npm run test_node` launches the tests in a nodejs context,
   - `npm run dev_browser` launches an auto-reload test server in a browser
-  context at <http://localhost:8080/webpack-dev-server/>
+  context at <http://localhost:8080/webpack-dev-server/>,
+  - `npm run lint` checks the coding style.
 
 ## Releasing a new version (needs administrator rights) ##
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "npm run test_node",
     "test_node": "mocha",
     "dev_browser": "cd test/browser && webpack-dev-server",
-    "prepublish": "npm run lint && npm run test && npm run build"
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "babel-cli": "6.3.17",


### PR DESCRIPTION
- The sources are now include when installing the client via npm
- The tests (that requires specific environment variables to be set) are disabled when executing `nom install`

This makes it easy to do install any branch of the repository for testing purposes:
1. `npm install craft-ai@craft-ai/craft-ai-client-js#my/branch` to install the package from github,
2. `cd node_modules/craft-ai && npm install` to build the package locally.