### PR TITLE
Support timezones as UTC offset in minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/craft-ai/craft-ai-client-js/compare/v1.15.4...HEAD) ##
 
+### Added ###
+
+- Support timezones as UTC offset in minutes
+
 ## [1.15.4](https://github.com/craft-ai/craft-ai-client-js/compare/v1.15.3...v1.15.4) - 2018-11-27 ##
 
 ### Changed ###

--- a/README.md
+++ b/README.md
@@ -354,47 +354,53 @@ Each agent has a configuration defining:
 - a `day_of_week` property is an integer belonging to **[0, 6]**, each value represents a day of the week starting from Monday (0 is Monday, 6 is Sunday).
 - a `day_of_month` property is an integer belonging to **[1, 31]**, each value represents a day of the month.
 - a `month_of_year` property is an integer belonging to **[1, 12]**, each value represents a month of the year.
-- a `timezone` property is a string value representing the timezone as an offset from UTC, supported format are:
+- a `timezone` property can be:
+  * a string value representing the timezone as an offset from UTC, supported formats are:
 
-  - **±[hh]:[mm]**,
-  - **±[hh][mm]**,
-  - **±[hh]**,
+    - **±[hh]:[mm]**,
+    - **±[hh][mm]**,
+    - **±[hh]**,
 
-  where `hh` represent the hour and `mm` the minutes from UTC (eg. `+01:30`)), between `-12:00` and
-  `+14:00`.
+    where `hh` represent the hour and `mm` the minutes from UTC (eg. `+01:30`)), between `-12:00` and
+    `+14:00`.
 
-  Some abbreviations are also supported:
+  * an integer belonging to **[-720, 840]** which represents the timezone as an offset from UTC:
 
-  - **UTC** or **Z** Universal Time Coordinated,
-  - **GMT** Greenwich Mean Time, as UTC,
-  - **BST** British Summer Time, as UTC+1 hour,
-  - **IST** Irish Summer Time, as UTC+1,
-  - **WET** Western Europe Time, as UTC,
-  - **WEST** Western Europe Summer Time, as UTC+1,
-  - **CET** Central Europe Time, as UTC+1,
-  - **CEST** Central Europe Summer Time, as UTC+2,
-  - **EET** Eastern Europe Time, as UTC+2,
-  - **EEST** Eastern Europe Summer Time, as UTC+3,
-  - **MSK** Moscow Time, as UTC+3,
-  - **MSD** Moscow Summer Time, as UTC+4,
-  - **AST** Atlantic Standard Time, as UTC-4,
-  - **ADT** Atlantic Daylight Time, as UTC-3,
-  - **EST** Eastern Standard Time, as UTC-5,
-  - **EDT** Eastern Daylight Saving Time, as UTC-4,
-  - **CST** Central Standard Time, as UTC-6,
-  - **CDT** Central Daylight Saving Time, as UTC-5,
-  - **MST** Mountain Standard Time, as UTC-7,
-  - **MDT** Mountain Daylight Saving Time, as UTC-6,
-  - **PST** Pacific Standard Time, as UTC-8,
-  - **PDT** Pacific Daylight Saving Time, as UTC-7,
-  - **HST** Hawaiian Standard Time, as UTC-10,
-  - **AKST** Alaska Standard Time, as UTC-9,
-  - **AKDT** Alaska Standard Daylight Saving Time, as UTC-8,
-  - **AEST** Australian Eastern Standard Time, as UTC+10,
-  - **AEDT** Australian Eastern Daylight Time, as UTC+11,
-  - **ACST** Australian Central Standard Time, as UTC+9.5,
-  - **ACDT** Australian Central Daylight Time, as UTC+10.5,
-  - **AWST** Australian Western Standard Time, as UTC+8.
+    - in hours if the integer belongs to **[-15, 15]**
+    - in minutes otherwise
+
+  * an abbreviation among the following:
+
+    - **UTC** or **Z** Universal Time Coordinated,
+    - **GMT** Greenwich Mean Time, as UTC,
+    - **BST** British Summer Time, as UTC+1 hour,
+    - **IST** Irish Summer Time, as UTC+1,
+    - **WET** Western Europe Time, as UTC,
+    - **WEST** Western Europe Summer Time, as UTC+1,
+    - **CET** Central Europe Time, as UTC+1,
+    - **CEST** Central Europe Summer Time, as UTC+2,
+    - **EET** Eastern Europe Time, as UTC+2,
+    - **EEST** Eastern Europe Summer Time, as UTC+3,
+    - **MSK** Moscow Time, as UTC+3,
+    - **MSD** Moscow Summer Time, as UTC+4,
+    - **AST** Atlantic Standard Time, as UTC-4,
+    - **ADT** Atlantic Daylight Time, as UTC-3,
+    - **EST** Eastern Standard Time, as UTC-5,
+    - **EDT** Eastern Daylight Saving Time, as UTC-4,
+    - **CST** Central Standard Time, as UTC-6,
+    - **CDT** Central Daylight Saving Time, as UTC-5,
+    - **MST** Mountain Standard Time, as UTC-7,
+    - **MDT** Mountain Daylight Saving Time, as UTC-6,
+    - **PST** Pacific Standard Time, as UTC-8,
+    - **PDT** Pacific Daylight Saving Time, as UTC-7,
+    - **HST** Hawaiian Standard Time, as UTC-10,
+    - **AKST** Alaska Standard Time, as UTC-9,
+    - **AKDT** Alaska Standard Daylight Saving Time, as UTC-8,
+    - **AEST** Australian Eastern Standard Time, as UTC+10,
+    - **AEDT** Australian Eastern Daylight Time, as UTC+11,
+    - **ACST** Australian Central Standard Time, as UTC+9.5,
+    - **ACDT** Australian Central Daylight Time, as UTC+10.5,
+    - **AWST** Australian Western Standard Time, as UTC+8.
 
 > :information_source: By default, the values of the `time_of_day` and `day_of_week`
 > properties are generated from the [`timestamp`](#timestamp) of an agent's

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,7 @@ export namespace Property {
 
   type Enum<T extends string> = [Property<'enum'>, T]
   type Continuous = [Property<'continuous'>, number]
-  type Timezone = [Property<'timezone'>, string]
+  type Timezone = [Property<'timezone'>, string | number]
   type DayOfMonth = [GeneratedProperty<'day_of_month'>, number]
   type DayOfWeek = [GeneratedProperty<'day_of_week'>, number]
   type MonthOfYear = [GeneratedProperty<'month_of_year'>, number]
@@ -238,7 +238,7 @@ export interface Client {
 
 export interface Time {
   timestamp: number
-  timezone: string
+  timezone: string | number
   time_of_day: number
   day_of_month: number
   month_of_year: number

--- a/src/timezones.js
+++ b/src/timezones.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 const TIMEZONE_REGEX = /^([+-](2[0-3]|[01][0-9])(:?[0-5][0-9])?|Z)$/; // +/-00:00 -/+00 Z +/-0000
 
 export const timezones = {
@@ -34,9 +36,13 @@ export const timezones = {
 };
 
 const isTimezone = (value) => {
-  const resultRegexp = TIMEZONE_REGEX.test(value);
-  const resultAbbreviations = timezones[value] != undefined;
-  return resultRegexp || resultAbbreviations;
+  return _.isInteger(value)
+    ? value <= 840 && value >= -720
+    : _.isString(value) && (value in timezones || TIMEZONE_REGEX.test(value));
 };
+
+export function getTimezoneKey(configuration) {
+  return _.findKey(configuration, { 'type': 'timezone' });
+}
 
 export default isTimezone;

--- a/test/test_time.js
+++ b/test/test_time.js
@@ -361,19 +361,55 @@ describe('Time(...)', function() {
         timezone: '+01:00'
       });
     });
+
+    it('works with a Time having a specified timezone and a given timezone (320)', function() {
+      expect(new Time(Time('1977-04-22T01:00:00-05:00'), 330)).to.be.deep.equal({
+        utc: '1977-04-22T06:00:00.000Z',
+        timestamp: 230536800,
+        day_of_week: 4,
+        time_of_day: 11.5,
+        day_of_month: 22,
+        month_of_year: 4,
+        timezone: '+05:30'
+      });
+    });
+
+    it('works with a Time having a specified timezone and a given timezone (-320)', function() {
+      expect(new Time(Time('1977-04-22T01:00:00-05:00'), -330)).to.be.deep.equal({
+        utc: '1977-04-22T06:00:00.000Z',
+        timestamp: 230536800,
+        day_of_week: 4,
+        time_of_day: 0.5,
+        day_of_month: 22,
+        month_of_year: 4,
+        timezone: '-05:30'
+      });
+    });
   });
 
   describe('from anythings(...)', function() {
-    it('don\'t works with non time string', function() {
+    it('doesn\'t work with non time string', function() {
       expect(() => Time('toto')).to.throw(CraftAiTimeError);
     });
 
-    it('don\'t works with object', function() {
+    it('doesn\'t work with object', function() {
       expect(() => Time({ toto: 'toto' })).to.throw(CraftAiTimeError);
     });
 
-    it('don\'t works with array containing alphabetical string', function() {
+    it('doesn\'t work with array containing alphabetical string', function() {
       expect(() => Time(['aaa152'])).to.throw(CraftAiTimeError);
+    });
+
+    it('doesn\'t work with a Time having an invalid specified timezone (900)', function() {
+      expect(() => new Time(Time('1977-04-22T01:00:00-05:00'), 900)).to.throw(CraftAiTimeError);
+    });
+
+    it('doesn\'t work with a Time having an invalid specified timezone (-730)', function() {
+      expect(() => new Time(Time('1977-04-22T01:00:00-05:00'), -730)).to.throw(CraftAiTimeError);
+    });
+
+    it('doesn\'t work with a Time having an invalid specified timezone ("aaaa")', function() {
+      expect(() => new Time(Time('1977-04-22T01:00:00-05:00'), 'aaaa')).to.throw(CraftAiTimeError);
     });
   });
 });


### PR DESCRIPTION
Part  2 of craft-ai/craft-ai-client-js#130.
Supporting timezones as UTC offset in the JS client.