### PR TITLE
Property values under 10^-2 uses scientific notation in .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/craft-ai/craft-ai-client-js/compare/v1.17.1...HEAD) ##
 
+### Fixed ###
+
+- Property values under 10^-2 uses scientific notation in `interpreter.formatDecisionRules`.
+
 ## [1.17.1](https://github.com/craft-ai/craft-ai-client-js/compare/v1.17.0...v1.17.1) - 2019-08-14 ##
 
 ### Changed ###

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -21,7 +21,10 @@ const MONTH = [
 
 const PROPERTY_FORMATTER = {
   [TYPE_ANY]: (value) => value,
-  [TYPES.continuous]: (number) => `${Math.round(number * 100) / 100}`,
+  [TYPES.continuous]: (number) =>
+    number > 0.01 ? `${Math.round(number * 100) / 100}` :
+      number.toExponential(2)
+  ,
   [TYPES.time_of_day]: (time) => {
     const _time = time instanceof Time ? time.time_of_day : time;
     const hours = Math.floor(_time);


### PR DESCRIPTION
Need to adjust the interpreeter test suite and python client
But since this feature is only necessary for the react component and the branches labels, I don't think it is mandatory to add it to Python and global tests