### PR TITLE
Add boolean type for context operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added ###
 
 - Add nbOperationsAdded field in response result when contexts operations are added.
+- Support boolean type inside the interpreter formatter.
 
 ## [1.19.0](https://github.com/craft-ai/craft-ai-client-js/compare/v1.18.3...v1.19.0) - 2020-05-04 ##
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,7 @@ export const AGENT_ID_MAX_LENGTH = 36;
 export const AGENT_ID_ALLOWED_REGEXP = /^([a-z0-9_-]){1,36}$/i;
 
 export const TYPES = {
+  boolean: 'boolean',
   continuous: 'continuous',
   enum: 'enum',
   timezone: 'timezone',

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -21,6 +21,7 @@ const MONTH = [
 
 const PROPERTY_FORMATTER = {
   [TYPE_ANY]: (value) => value,
+  [TYPES.boolean]: (bool) => bool.toString(),
   [TYPES.continuous]: (number) =>
     number > 0.01 ? `${Math.round(number * 100) / 100}` :
       number.toExponential(2)

--- a/test/test_formatter.js
+++ b/test/test_formatter.js
@@ -71,4 +71,12 @@ describe('interpreter.formatProperty', () => {
       expect(interpreter.formatProperty('time_of_day', date)).to.be.equal('18:23');
     });
   });
+  describe('on boolean values', () => {
+    it('From \'false\'', () => {
+      expect(interpreter.formatProperty('boolean', false)).to.be.equal('false');
+    });
+    it('From \'true\'', () => {
+      expect(interpreter.formatProperty('boolean', true)).to.be.equal('true');
+    });
+  });
 });

--- a/test/test_properties.js
+++ b/test/test_properties.js
@@ -34,6 +34,14 @@ describe('Properties', () => {
         expect(formatter(12)).to.be.equal('Dec');
       });
     });
+
+    describe(TYPES.boolean, () => {
+      const formatter = formatProperty(TYPES.boolean);
+      it('Works properly on property values', () => {
+        expect(formatter(false)).to.be.equal('false');
+        expect(formatter(true)).to.be.equal('true');
+      });
+    });
   });
 
   describe('.formatDecisionRule(<decision_rule>)', () => {


### PR DESCRIPTION
Add boolean type for context operation in the formatter.
Update tests accordingly.